### PR TITLE
Registration failed if the base ApplicationUser model is extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Kentico Xperience 13 on .Net core 3.1 or above
 # Installation
 1. On your Xperience MVC Site, install the `XperienceCommunity.WidgetFilter` nuget package.
 1. In your startup, call `services.AddWidgetFilter()`
+1. If you have extended the base ApplicationUser class call `services.AddWidgetFilter<TUser>()`
 1. Add `@addTagHelper *, XperienceCommunity.WidgetFilter` to your `_ViewImports.cshtml` or whichever view you wish to get the tag helper.
 
 # Usage

--- a/XperienceCommunity.WidgetFilter/Implementations/WidgetPermissionFilter.cs
+++ b/XperienceCommunity.WidgetFilter/Implementations/WidgetPermissionFilter.cs
@@ -14,17 +14,17 @@ using System.Threading.Tasks;
 
 namespace XperienceCommunity.WidgetFilter
 {
-    public class WidgetPermissionFilter : IWidgetPermissionFilter
+    public class WidgetPermissionFilter<TUser> : IWidgetPermissionFilter where TUser : ApplicationUser
     {
         private readonly IUserInfoProvider _userInfoProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly UserManager<TUser> _userManager;
         private readonly ISiteService _siteService;
         private readonly IProgressiveCache _progressiveCache;
 
         public WidgetPermissionFilter(IUserInfoProvider userInfoProvider, 
             IHttpContextAccessor httpContextAccessor,
-            UserManager<ApplicationUser> userManager,
+            UserManager<TUser> userManager,
             ISiteService siteService,
             IProgressiveCache progressiveCache)
         {

--- a/XperienceCommunity.WidgetFilter/WidgetFilterIServiceCollectionExtension.cs
+++ b/XperienceCommunity.WidgetFilter/WidgetFilterIServiceCollectionExtension.cs
@@ -1,14 +1,27 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Kentico.Membership;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace XperienceCommunity.WidgetFilter
 {
     public static class WidgetFilterIServiceCollectionExtension
     {
+        public static IServiceCollection AddWidgetFilter<TUser>(this IServiceCollection services) 
+            where TUser : ApplicationUser
+        {
+            return AddWidgetFilterInternal(services)
+                .AddScoped<IWidgetPermissionFilter, WidgetPermissionFilter<TUser>>();
+        }
+
         public static IServiceCollection AddWidgetFilter(this IServiceCollection services)
         {
-            services.AddSingleton<IWidgetSetFilter, WidgetSetFilter>();
-            services.AddScoped<IWidgetPermissionFilter, WidgetPermissionFilter>();
-            return services;
+            return AddWidgetFilterInternal(services)
+                .AddScoped<IWidgetPermissionFilter, WidgetPermissionFilter<ApplicationUser>>();
+        }
+
+        private static IServiceCollection AddWidgetFilterInternal(IServiceCollection services)
+        {
+            return services
+                .AddSingleton<IWidgetSetFilter, WidgetSetFilter>();
         }
     }
 }

--- a/XperienceCommunity.WidgetFilter/XperienceCommunity.WidgetFilter.csproj
+++ b/XperienceCommunity.WidgetFilter/XperienceCommunity.WidgetFilter.csproj
@@ -9,7 +9,7 @@
     <Description>Ability to have widgets designated to "Sets" as well as limit widgets based on user, role, or site.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/KenticoDevTrev/XperienceCommunity.WidgetFilter</PackageProjectUrl>
-    <PackageIcon>hbs-favicon-96x96.png</PackageIcon>
+    <!--<PackageIcon>hbs-favicon-96x96.png</PackageIcon>-->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KenticoDevTrev/XperienceCommunity.WidgetFilter</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -23,10 +23,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Include="..\..\hbs-favicon-96x96.png">
+	  <!--<None Include="..\..\hbs-favicon-96x96.png">
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
-	  </None>
+	  </None>-->
 	  <None Include="..\README.md">
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>


### PR DESCRIPTION
Implemented a generic registration of the `WidgetPermissionFilter` to allow the UserManager to be properly resolved when the application is configured using an extended Application Identity model such as the following.

```csharp
         services.AddApplicationIdentity<ExtendedApplicationUser, ApplicationRole>()
                .AddApplicationDefaultTokenProviders()
                .AddUserStore<ApplicationUserStore<ExtendedApplicationUser>>()
                .AddRoleStore<ApplicationRoleStore<ApplicationRole>>()
                .AddUserManager<ApplicationUserManager<ExtendedApplicationUser>>()
                .AddSignInManager<SignInManager<ExtendedApplicationUser>>();

        services.AddWidgetSets(); //Will fail because of UserManager<ApplicationUser> is not registered
        services.AddWidgetSets<ExtendedApplicationUser>(); ///now properly resolves UserManager<ExtendedApplicationUser>
```